### PR TITLE
Revert commit that disabled sleeps if visualisation is off

### DIFF
--- a/rrc_2022_datasets/sim_env.py
+++ b/rrc_2022_datasets/sim_env.py
@@ -217,7 +217,8 @@ class SimTriFingerCubeEnv(gym.Env):
         """Append desired action to queue and wait if real time is enabled."""
 
         t = self.platform.append_desired_action(robot_action)
-        if self.real_time:
+        # TODO: shouldn't it always sleep if real_time is true?
+        if self.visualization and self.real_time:
             sleep(max(0.001 - (time() - self.time_of_last_step), 0.0))
             self.time_of_last_step = time()
         return t

--- a/rrc_2022_datasets/sim_env.py
+++ b/rrc_2022_datasets/sim_env.py
@@ -49,10 +49,10 @@ class SimTriFingerCubeEnv(gym.Env):
                 and application of the action computed from this
                 observation in milliseconds.
             reward_type (str): Which reward to use. Can be 'dense' or 'sparse'.
-            visualization (bool): If true, the PyBullet GUI is run for
-                visualization.
+            visualization (bool): If true, the PyBullet GUI is run for visualization.
             real_time (bool): If true, the environment is stepped in real
-                time instead of as fast as possible.
+                time instead of as fast as possible (ignored if visualization is
+                disabled).
         """
         # Basic initialization
         # ====================
@@ -217,7 +217,6 @@ class SimTriFingerCubeEnv(gym.Env):
         """Append desired action to queue and wait if real time is enabled."""
 
         t = self.platform.append_desired_action(robot_action)
-        # TODO: shouldn't it always sleep if real_time is true?
         if self.visualization and self.real_time:
             sleep(max(0.001 - (time() - self.time_of_last_step), 0.0))
             self.time_of_last_step = time()


### PR DESCRIPTION
There is no practical use to have a sleep in each step if visualisation is off, so revert the corresponding commit.
Also add a note in the docstring that the `real_time` argument is only relevant if visualisation is enabled.

Tested by running the evaluation with an example policy once with visualisation enabled once disabled and compared the time it took.