### PR TITLE
Add warning if stepped too slow and fix counting of steps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+
+## [1.1.1] - 2022-09-06
 ### Added
 - Print warnings if the step-function of SimTriFingerCubeEnv is called at a too low
   rate.  This way the users get some indication if their policy is taking too much time.
@@ -34,7 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 First release
 
 
-[Unreleased]: https://github.com/rr-learning/rrc_2022_datasets/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/rr-learning/rrc_2022_datasets/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/rr-learning/rrc_2022_datasets/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/rr-learning/rrc_2022_datasets/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/rr-learning/rrc_2022_datasets/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/rr-learning/rrc_2022_datasets/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Added
+- Print warnings if the step-function of SimTriFingerCubeEnv is called at a too low
+  rate.  This way the users get some indication if their policy is taking too much time.
+
+### Fixed
+- Count environment steps instead of robot steps to determine end of the episode.  This
+  fixes an issue that calling step() at a too low rate could cause in too many
+  environment steps to be executed.
+
 
 ## [1.1.0] - 2022-08-02
+### Added
 - Add datasets for the real-robot stage
 
 ## [1.0.1] - 2022-07-04

--- a/rrc_2022_datasets/__init__.py
+++ b/rrc_2022_datasets/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 from gym.envs.registration import register
 

--- a/rrc_2022_datasets/sim_env.py
+++ b/rrc_2022_datasets/sim_env.py
@@ -321,6 +321,8 @@ class SimTriFingerCubeEnv(gym.Env):
         if not self._check_action(action):
             raise ValueError("Given action is not contained in the action space.")
 
+        self.step_count += 1
+
         # get robot action
         robot_action = self._gym_action_to_robot_action(action)
 
@@ -346,7 +348,7 @@ class SimTriFingerCubeEnv(gym.Env):
                 if extreme:
                     self.logger.error(
                         "ERROR: Control loop got delayed by more than a full step."
-                        "  Timing of the episode will be affected!"
+                        "  Timing of the episode will be significantly affected!"
                     )
             else:
                 self._timing_violation_counter = 0
@@ -357,7 +359,6 @@ class SimTriFingerCubeEnv(gym.Env):
         # ahead by more than one step size.
         t = self.t_obs + self.obs_action_delay
         while t < self.t_obs + self._step_size:
-            self.step_count += 1
             t = self._append_desired_action(robot_action)
         # time of the new observation
         self.t_obs = t

--- a/rrc_2022_datasets/sim_env.py
+++ b/rrc_2022_datasets/sim_env.py
@@ -283,7 +283,7 @@ class SimTriFingerCubeEnv(gym.Env):
             b_conj = b.conjugate()
             quat_prod = a * b_conj
             norm = np.linalg.norm([quat_prod.x, quat_prod.y, quat_prod.z])
-            norm = min(norm, 1.0)
+            norm = min(norm, 1.0)  # type: ignore
             angle = 2.0 * np.arcsin(norm)
             orientation_check = angle < 2.0 * np.pi * ANGLE_THRESHOLD_DEG / 360.0
 
@@ -366,19 +366,20 @@ class SimTriFingerCubeEnv(gym.Env):
         reward = self.compute_reward(
             observation["achieved_goal"], observation["desired_goal"], info
         )
-        is_done = self.step_count >= self.episode_length * self._step_size
+        is_done = self.step_count >= self.episode_length
 
         if not is_done and preappend_actions:
             # Append action to action queue of robot for as many time
             # steps as the obs_action_delay dictates. This gives the
             # user time to evaluate the policy.
             for _ in range(self.obs_action_delay):
-                self.step_count += 1
                 self._append_desired_action(robot_action)
 
         return observation, reward, is_done, info
 
-    def reset(self, return_info: bool = False, preappend_actions: bool = True):
+    def reset(  # type: ignore
+        self, return_info: bool = False, preappend_actions: bool = True
+    ):
         """Reset the environment."""
 
         super().reset(return_info=return_info)


### PR DESCRIPTION
- Print warnings if the step-function of SimTriFingerCubeEnv is called at a too low
  rate.  This way the users get some indication if their policy is taking too much time.
- Count environment steps instead of robot steps to determine end of the episode.  This
  fixes an issue that calling step() at a too low rate could cause in too many
  environment steps to be executed.
- Bump version to 1.1.1